### PR TITLE
[copyicu] Copy dir to swift/../icu

### DIFF
--- a/copyicu.sh
+++ b/copyicu.sh
@@ -5,3 +5,7 @@ do
 	echo $i
 	$mystrip -o ../build/Ninja-ReleaseAssert+stdlib-DebugAssert/swift-linux-x86_64/lib/swift/android/`basename $i` $i
 done
+
+# icu must be placed in ../icu, relative to swift source directory.
+# See: https://github.com/apple/swift/compare/master...SwiftAndroid:20dbe893a8f2fb77bf8fc7f067c602d273181362?expand=1#diff-820a1d13441195f42bb1712046b14552R29
+cp -r ../libiconv-libicu-android/armeabi-v7a/icu ../icu


### PR DESCRIPTION
After building libicu, the directory needs to the copied to the
location expected by the build script; see:
https://github.com/apple/swift/compare/master...SwiftAndroid:20dbe893a8f2fb77bf8fc7f067c602d273181362?expand=1#diff-820a1d13441195f42bb1712046b14552R29

Add this step to the `copyicu.sh` script, to make it a little
easier for contributors to pick up on.
